### PR TITLE
Virtual layer improvement (Layer Box, Layer Controller)

### DIFF
--- a/src/lib/Layout/Layers/PanelCanvas.tsx
+++ b/src/lib/Layout/Layers/PanelCanvas.tsx
@@ -9,6 +9,13 @@ const App = () => {
 	const [_canvasWidth, _setCanvasWidth] = React.useState<number>(canvasState.width);
 	const [_canvasHeight, _setCanvasHeight] = React.useState<number>(canvasState.height);
 
+	function onClickApply() {
+		setCanvasState({
+			width: _canvasWidth,
+			height: _canvasHeight,
+		});
+	}
+
 	return (
 		<GuideBox width='100%' spacing={2}>
 			<GuideBox width='100%' spacing={1} horRight>
@@ -28,16 +35,7 @@ const App = () => {
 				/>
 			</GuideBox>
 			<GuideBox width='100%' horRight>
-				<Button
-					onClick={() => {
-						setCanvasState({
-							width: _canvasWidth,
-							height: _canvasHeight,
-						});
-					}}
-				>
-					Apply
-				</Button>
+				<Button onClick={onClickApply}>Apply</Button>
 			</GuideBox>
 		</GuideBox>
 	);

--- a/src/lib/Layout/Layers/PanelControllerVirtualLayerValues.tsx
+++ b/src/lib/Layout/Layers/PanelControllerVirtualLayerValues.tsx
@@ -1,5 +1,7 @@
 import { GuideBox, IconButton, Icon, TextFieldV2, Tooltip } from '@midasit-dev/moaui';
+import { useRecoilValue } from 'recoil';
 import { useController } from './useController';
+import { CanvasState } from '../recoilState';
 
 const App = () => {
 	const {
@@ -11,34 +13,44 @@ const App = () => {
 		handleChangeHeight,
 	} = useController();
 
+	const canvasState = useRecoilValue(CanvasState);
+
 	return (
 		<GuideBox width='100%'>
 			<GuideBox width='100%' spacing={1}>
 				<TextFieldV2
 					title='x'
 					onChange={handleChangeX}
-					numberOptions={{ onlyInteger: true, min: 0 }}
+					numberOptions={{
+						onlyInteger: true,
+						min: 0,
+						max: canvasState.width - controllerState.width,
+					}}
 					type='number'
 					value={controllerState.x.toString()}
 				/>
 				<TextFieldV2
 					title='y'
 					onChange={handleChangeY}
-					numberOptions={{ onlyInteger: true, min: 0 }}
+					numberOptions={{
+						onlyInteger: true,
+						min: 0,
+						max: canvasState.height - controllerState.height,
+					}}
 					type='number'
 					value={controllerState.y.toString()}
 				/>
 				<TextFieldV2
 					title='width'
 					onChange={handleChangeWidth}
-					numberOptions={{ onlyInteger: true, min: 0 }}
+					numberOptions={{ onlyInteger: true, min: 0, max: canvasState.width }}
 					type='number'
 					value={controllerState.width.toString()}
 				/>
 				<TextFieldV2
 					title='height'
 					onChange={handleChangeHeight}
-					numberOptions={{ onlyInteger: true, min: 0 }}
+					numberOptions={{ onlyInteger: true, min: 0, max: canvasState.height }}
 					type='number'
 					value={controllerState.height.toString()}
 				/>

--- a/src/lib/Layout/Layers/useController.tsx
+++ b/src/lib/Layout/Layers/useController.tsx
@@ -3,6 +3,7 @@ import { Rnd } from 'react-rnd';
 import '../VirtualLayer.css';
 import { useRecoilState } from 'recoil';
 import { defaultControllerState, ControllerState } from '../recoilState';
+import { round } from 'lodash';
 
 export const useController = () => {
 	const [controllerState, setControllerState] = useRecoilState(ControllerState);
@@ -70,7 +71,7 @@ export const useController = () => {
 				enableResizing={true}
 				disableDragging={false}
 				onDragStop={(e, d) => {
-					setControllerState((prev) => ({ ...prev, x: d.x, y: d.y }));				
+					setControllerState((prev) => ({ ...prev, x: d.x, y: round(d.y) }));				
 				}}
 				onResizeStop={(e, direction, ref, delta, position) => {
 					setControllerState((prev) => ({
@@ -78,7 +79,7 @@ export const useController = () => {
 						width: ref.offsetWidth,
 						height: ref.offsetHeight,
 						x: position.x,
-						y: position.y,
+						y: round(position.y),
 					}));
 				
 				}}

--- a/src/lib/Layout/Layers/useController.tsx
+++ b/src/lib/Layout/Layers/useController.tsx
@@ -1,12 +1,13 @@
 import React, { useState } from 'react';
 import { Rnd } from 'react-rnd';
 import '../VirtualLayer.css';
-import { useRecoilState } from 'recoil';
-import { defaultControllerState, ControllerState } from '../recoilState';
+import { useRecoilState, useRecoilValue } from 'recoil';
+import { defaultControllerState, ControllerState, CanvasState } from '../recoilState';
 import { round } from 'lodash';
 
 export const useController = () => {
 	const [controllerState, setControllerState] = useRecoilState(ControllerState);
+	const canvasState = useRecoilValue(CanvasState);
 
 	const initialize = React.useCallback(
 		(inputs = defaultControllerState) => {
@@ -19,30 +20,48 @@ export const useController = () => {
 
 	const handleChangeX = React.useCallback(
 		(e: React.ChangeEvent<HTMLInputElement>) => {
-			setControllerState((prev) => ({ ...prev, x: Number(e.target.value) }));
+			let xValue = Number(e.target.value);
+			if (xValue + controllerState.width > canvasState.width) {
+				xValue = canvasState.width - controllerState.width;
+			}
+			setControllerState((prev) => ({ ...prev, x: xValue }));
 		},
-		[setControllerState],
+		[canvasState.width, controllerState.width, setControllerState],
 	);
 
 	const handleChangeY = React.useCallback(
 		(e: React.ChangeEvent<HTMLInputElement>) => {
-			setControllerState((prev) => ({ ...prev, y: Number(e.target.value) }));
+			let yValue = Number(e.target.value);
+			if (yValue + controllerState.height > canvasState.height) {
+				yValue = canvasState.height - controllerState.height;
+			}
+			setControllerState((prev) => ({ ...prev, y: yValue }));
 		},
-		[setControllerState],
+		[canvasState.height, controllerState.height, setControllerState],
 	);
 
 	const handleChangeWidth = React.useCallback(
 		(e: React.ChangeEvent<HTMLInputElement>) => {
-			setControllerState((prev) => ({ ...prev, width: Number(e.target.value) }));
+			let widthValue = Number(e.target.value);
+			if (controllerState.x + widthValue > canvasState.width) {
+				let xValue = canvasState.width - widthValue;
+				setControllerState((prev) => ({ ...prev, x: xValue }));
+			}
+			setControllerState((prev) => ({ ...prev, width: widthValue }));
 		},
-		[setControllerState],
+		[canvasState.width, controllerState.x, setControllerState],
 	);
 
 	const handleChangeHeight = React.useCallback(
 		(e: React.ChangeEvent<HTMLInputElement>) => {
+			let heightValue = Number(e.target.value);
+			if (controllerState.y + heightValue > canvasState.height) {
+				let yValue = canvasState.height - heightValue;
+				setControllerState((prev) => ({ ...prev, y: yValue }));
+			}
 			setControllerState((prev) => ({ ...prev, height: Number(e.target.value) }));
 		},
-		[setControllerState],
+		[canvasState.height, controllerState.y, setControllerState],
 	);
 
 	const handleChangeSpacing = React.useCallback(
@@ -71,7 +90,7 @@ export const useController = () => {
 				enableResizing={true}
 				disableDragging={false}
 				onDragStop={(e, d) => {
-					setControllerState((prev) => ({ ...prev, x: d.x, y: round(d.y) }));				
+					setControllerState((prev) => ({ ...prev, x: d.x, y: round(d.y) }));
 				}}
 				onResizeStop={(e, direction, ref, delta, position) => {
 					setControllerState((prev) => ({
@@ -81,7 +100,6 @@ export const useController = () => {
 						x: position.x,
 						y: round(position.y),
 					}));
-				
 				}}
 			/>
 		);

--- a/src/lib/Layout/Layers/useController.tsx
+++ b/src/lib/Layout/Layers/useController.tsx
@@ -67,8 +67,21 @@ export const useController = () => {
 					height: controllerState.height,
 				}}
 				bounds='parent'
-				enableResizing={false}
-				disableDragging={true}
+				enableResizing={true}
+				disableDragging={false}
+				onDragStop={(e, d) => {
+					setControllerState((prev) => ({ ...prev, x: d.x, y: d.y }));				
+				}}
+				onResizeStop={(e, direction, ref, delta, position) => {
+					setControllerState((prev) => ({
+						...prev,
+						width: ref.offsetWidth,
+						height: ref.offsetHeight,
+						x: position.x,
+						y: position.y,
+					}));
+				
+				}}
 			/>
 		);
 	}, [

--- a/src/lib/Layout/Layers/useController.tsx
+++ b/src/lib/Layout/Layers/useController.tsx
@@ -103,7 +103,36 @@ export const useController = () => {
 						y: round(position.y),
 					}));
 				}}
-			/>
+			>
+				<div
+					style={{
+						display: 'flex',
+						justifyContent: 'center',
+						alignItems: 'center',
+						flexDirection: 'column',
+						height: controllerState.height,
+					}}
+				>
+					<div
+						className='virtual-layer-content'
+						style={{
+							fontSize: controllerState.height < 90 ? '12px' : '15px',
+							marginBottom: controllerState.height < 90 ? '8px' : '15px',
+						}}
+					>
+						Create layer
+					</div>
+					<div
+						className='virtual-layer-content'
+						style={{
+							color: 'gray',
+							fontSize: controllerState.height < 90 ? '12px' : '15px',
+						}}
+					>
+						'Ctrl + Enter'
+					</div>
+				</div>
+			</Rnd>
 		);
 	}, [
 		controllerState.height,

--- a/src/lib/Layout/Layers/useController.tsx
+++ b/src/lib/Layout/Layers/useController.tsx
@@ -45,6 +45,7 @@ export const useController = () => {
 			let widthValue = Number(e.target.value);
 			if (controllerState.x + widthValue > canvasState.width) {
 				let xValue = canvasState.width - widthValue;
+				if (xValue < 0) xValue = 0;
 				setControllerState((prev) => ({ ...prev, x: xValue }));
 			}
 			setControllerState((prev) => ({ ...prev, width: widthValue }));
@@ -57,6 +58,7 @@ export const useController = () => {
 			let heightValue = Number(e.target.value);
 			if (controllerState.y + heightValue > canvasState.height) {
 				let yValue = canvasState.height - heightValue;
+				if (yValue < 0) yValue = 0;
 				setControllerState((prev) => ({ ...prev, y: yValue }));
 			}
 			setControllerState((prev) => ({ ...prev, height: Number(e.target.value) }));

--- a/src/lib/Layout/VirtualLayer.css
+++ b/src/lib/Layout/VirtualLayer.css
@@ -10,3 +10,11 @@
 	/* animation: pulsate 6s linear infinite; */
 	background-color: rgba(75, 154, 244, 0.7);
 }
+
+.virtual-layer-content {
+	display: flex;
+	justify-content: center;
+	align-items: center;
+	color: darkblue;
+	font-weight: 500;
+}


### PR DESCRIPTION
<h2>[ 수정 사항 ]</h2>

<h3>[ VirtualLayer를 D&D 할 수 있도록 변경 & Controller 값과 Sync ]</h3>

- VirtualLayer D&D 기능 지원.

- VirtualLayer 테두리에 마우스 후버시 Resizing 기능 지원.

*위 2가지 동작에 대해 Layer Controller의 x, y, width, height 실시간 동기화 되도록 수정.

---
<h3>[ Canvas를 크기를 벗어나는 x,y 좌표 값 또는 width, height를 layer Controller에 입력했을 때, <br/> 자동 보정하도록 수정 ]</h3>

- X 입력 : X 변경 값 + width 값이 Canvas width 보다 클 경우, X 좌표 값을 자동 보정. (canvas.width - layer.width)

- Y 입력 : Y 변경 값 + height 값이 Canvas height 보다 클 경우, Y 좌표 값을 자동 보정. (canvas.height - layer.height)

- width 입력 : X 값 + width 변경 값이 Canvas width 보다 클 경우, width 변경 값을 유지하고 X 좌표를 자동 보정. (canvas.width - layer.width)

- height 입력 : Y 값 + height 변경 값이 Canvas height 보다 클 경우, height 변경 값을 유지하고 Y 좌표를 자동 보정. (canvas.height - layer.height)

- TextFieldV2의 max 속성 값 사용하여 UI에 입력할 수 있는 최댓값을 표시되도록 수정.
---
<h3>[ Virtual Layer에 텍스트 추가하여 Layer 생성 위치를 표시하는 Box임을 알 수 있도록 개선 ]</h3>

- 'Create Layer'

- 'Ctrl + Enter'

*공통 CSS는 VirtualLayer.css에 추가, Layer 높이 90을 기준으로 fontSize 조절되도록 설정.

![image](https://github.com/midasit-dev/playground/assets/40168374/5112686e-f8a0-4d47-af04-e97c5f5e4b1a)

